### PR TITLE
Declare InfoApp as product_specific like other added prebuilts

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -4,4 +4,5 @@ android_app_import {
     apk: "prebuilt/Info.apk",
     presigned: true,
     preprocessed: true,
+    product_specific: true,
 }


### PR DESCRIPTION
Required to keep emulator targets functional, and for consistency with other added prebuilts downstream